### PR TITLE
Don't fail if there are no favorite posts

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -23,7 +23,7 @@ after_initialize {
         
         favorite_posts = get_favorite_posts
         favorite_post_id = nil
-        if favorite_posts
+        if favorite_posts.length > 0
           favorite_post_id = favorite_posts[0].id
         end
         


### PR DESCRIPTION
If there are no posts returned by `get_favorite_posts` the test would fail. 

When there are zero favorite posts, `get_favorite_posts` returns and empty array, which would pass the test for existence but would fail to have a `x[0]` item.

This tests instead for an empty array and skips assigning a favorite post if there isn't one.

This has not been tested, but should do the trick.